### PR TITLE
add missing comma to webpack diff for css-loader

### DIFF
--- a/src/content/guides/asset-management.md
+++ b/src/content/guides/asset-management.md
@@ -72,7 +72,8 @@ __webpack.config.js__
     output: {
       filename: 'bundle.js',
       path: path.resolve(__dirname, 'dist')
-    },
+-   }
++   },
 +   module: {
 +     rules: [
 +       {


### PR DESCRIPTION
Fixes a bug in "Asset Management" where part of a diff was missing. A comma was added after the `output` section.